### PR TITLE
Add photonic ZNE mitigation utilities

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -5,6 +5,7 @@ qlass
    :maxdepth: 4
 
    qlass.compiler
+   qlass.mitigation
    qlass.quantum_chemistry
    qlass.utils
    qlass.vqe

--- a/docs/qlass.mitigation.rst
+++ b/docs/qlass.mitigation.rst
@@ -1,0 +1,29 @@
+qlass.mitigation package
+========================
+
+Submodules
+----------
+
+qlass.mitigation.m3 module
+--------------------------
+
+.. automodule:: qlass.mitigation.m3
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qlass.mitigation.zne module
+---------------------------
+
+.. automodule:: qlass.mitigation.zne
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: qlass.mitigation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/qlass.rst
+++ b/docs/qlass.rst
@@ -5,6 +5,7 @@ qlass package
    :maxdepth: 4
    
    qlass.compiler
+   qlass.mitigation
    qlass.quantum_chemistry
    qlass.utils
    qlass.vqe

--- a/src/qlass/mitigation/__init__.py
+++ b/src/qlass/mitigation/__init__.py
@@ -1,3 +1,10 @@
 from .m3 import M3Mitigator, PhotonicErrorModel
+from .zne import ZNEMitigator, fold_global_interferometer, scale_loss_config
 
-__all__ = ["M3Mitigator", "PhotonicErrorModel"]
+__all__ = [
+    "M3Mitigator",
+    "PhotonicErrorModel",
+    "ZNEMitigator",
+    "fold_global_interferometer",
+    "scale_loss_config",
+]

--- a/src/qlass/mitigation/zne.py
+++ b/src/qlass/mitigation/zne.py
@@ -9,9 +9,12 @@ from qlass.compiler import HardwareConfig
 
 
 def _validate_scaling_factor(scaling_factor: float) -> float:
-    if scaling_factor < 1:
+    factor = float(scaling_factor)
+    if not np.isfinite(factor):
+        raise ValueError("Noise scaling factors must be finite real numbers.")
+    if factor < 1:
         raise ValueError("Noise scaling factors must be greater than or equal to 1.")
-    return float(scaling_factor)
+    return factor
 
 
 def _validate_global_folding_factor(scaling_factor: float) -> int:
@@ -167,6 +170,8 @@ class ZNEMitigator:
 
         x = np.array(self.scaling_factors, dtype=float)
         y = np.array(expectation_values, dtype=float)
+        if not np.all(np.isfinite(y)):
+            raise ValueError("Expectation values must be finite real numbers.")
 
         if self.extrapolation_method == "linear":
             return float(np.polyval(np.polyfit(x, y, 1), 0.0))

--- a/src/qlass/mitigation/zne.py
+++ b/src/qlass/mitigation/zne.py
@@ -1,0 +1,206 @@
+from collections.abc import Callable, Sequence
+from dataclasses import replace
+from typing import Any
+
+import numpy as np
+import perceval as pcvl
+
+from qlass.compiler import HardwareConfig
+
+
+def _validate_scaling_factor(scaling_factor: float) -> float:
+    if scaling_factor < 1:
+        raise ValueError("Noise scaling factors must be greater than or equal to 1.")
+    return float(scaling_factor)
+
+
+def _validate_global_folding_factor(scaling_factor: float) -> int:
+    _validate_scaling_factor(scaling_factor)
+    rounded_factor = round(scaling_factor)
+    if not np.isclose(scaling_factor, rounded_factor) or rounded_factor % 2 == 0:
+        raise ValueError("Global folding requires an odd integer scaling factor.")
+    return int(rounded_factor)
+
+
+def fold_global_interferometer(
+    circuit: pcvl.Circuit,
+    scaling_factor: float,
+) -> pcvl.Circuit:
+    """
+    Fold a deterministic linear optical circuit as ``U (U† U)^n``.
+
+    The folding factor must be an odd integer ``lambda = 2n + 1``. The original
+    circuit is copied first, then global ``U†`` and ``U`` blocks are appended for
+    each fold. This keeps the effective unitary unchanged while increasing the
+    deterministic interferometer depth before any post-selection layer.
+
+    Args:
+        circuit: Perceval linear optical circuit to fold.
+        scaling_factor: Odd integer noise scaling factor.
+
+    Returns:
+        Folded Perceval circuit with the same effective unitary.
+    """
+    if not isinstance(circuit, pcvl.Circuit):
+        raise TypeError("fold_global_interferometer expects a Perceval Circuit.")
+
+    odd_factor = _validate_global_folding_factor(scaling_factor)
+    num_folds = (odd_factor - 1) // 2
+    folded = circuit.copy()
+
+    if num_folds == 0:
+        return folded
+
+    unitary = np.array(circuit.compute_unitary(), dtype=complex)
+    unitary_dagger = unitary.conj().T
+
+    for _ in range(num_folds):
+        folded = folded // pcvl.Unitary(pcvl.Matrix(unitary_dagger), name="ZNE_Udg")
+        folded = folded // pcvl.Unitary(pcvl.Matrix(unitary), name="ZNE_U")
+
+    return folded
+
+
+def scale_loss_config(config: HardwareConfig, scaling_factor: float) -> HardwareConfig:
+    """
+    Return a copy of ``config`` with photonic loss rates scaled in dB.
+
+    Only the component loss and waveguide loss fields are scaled. Source efficiency,
+    detector efficiency, visibility, and other hardware parameters are preserved.
+
+    Args:
+        config: Baseline hardware configuration.
+        scaling_factor: Multiplicative loss scaling factor.
+
+    Returns:
+        New hardware configuration with scaled loss rates.
+    """
+    factor = _validate_scaling_factor(scaling_factor)
+    return replace(
+        config,
+        photon_loss_component_db=config.photon_loss_component_db * factor,
+        photon_loss_waveguide_db_per_cm=config.photon_loss_waveguide_db_per_cm * factor,
+    )
+
+
+class ZNEMitigator:
+    """
+    Zero Noise Extrapolation helper for expectation-value executors.
+
+    The wrapped executor is called once per scaling factor. It must return an
+    expectation value and accept the noise scale through the keyword configured by
+    ``scale_keyword``.
+    """
+
+    def __init__(
+        self,
+        executor: Callable[..., float],
+        scaling_factors: list[float],
+        extrapolation_method: str = "polynomial",
+        polynomial_degree: int = 2,
+        scale_keyword: str = "noise_scale",
+    ) -> None:
+        """
+        Initialize a ZNE mitigator.
+
+        Args:
+            executor: Callable returning an expectation value for a requested noise scale.
+            scaling_factors: Noise scaling factors used for the extrapolation.
+            extrapolation_method: One of ``"linear"``, ``"polynomial"``, or ``"exponential"``.
+            polynomial_degree: Degree used by polynomial extrapolation.
+            scale_keyword: Keyword used to pass each scaling factor to ``executor``.
+        """
+        if len(scaling_factors) < 2:
+            raise ValueError("ZNE requires at least two scaling factors.")
+        if len(set(scaling_factors)) != len(scaling_factors):
+            raise ValueError("Scaling factors must be unique.")
+
+        self.scaling_factors = [_validate_scaling_factor(factor) for factor in scaling_factors]
+        self.executor = executor
+        self.extrapolation_method = extrapolation_method.lower()
+        self.polynomial_degree = polynomial_degree
+        self.scale_keyword = scale_keyword
+
+        if self.extrapolation_method not in {"linear", "polynomial", "exponential"}:
+            raise ValueError(
+                "Invalid extrapolation_method. Use 'linear', 'polynomial', or 'exponential'."
+            )
+        if polynomial_degree < 1:
+            raise ValueError("polynomial_degree must be at least 1.")
+
+    def scaled_expectation_values(
+        self,
+        params: np.ndarray,
+        *executor_args: Any,
+        **executor_kwargs: Any,
+    ) -> list[float]:
+        """
+        Execute the wrapped expectation-value executor at each noise scale.
+
+        Args:
+            params: Variational parameters passed to the executor.
+            *executor_args: Additional positional arguments forwarded to the executor.
+            **executor_kwargs: Additional keyword arguments forwarded to the executor.
+
+        Returns:
+            Expectation values ordered like ``scaling_factors``.
+        """
+        values = []
+        for scaling_factor in self.scaling_factors:
+            call_kwargs = dict(executor_kwargs)
+            call_kwargs[self.scale_keyword] = scaling_factor
+            values.append(float(self.executor(params, *executor_args, **call_kwargs)))
+        return values
+
+    def extrapolate(self, expectation_values: Sequence[float]) -> float:
+        """
+        Extrapolate expectation values to the zero-noise limit.
+
+        Args:
+            expectation_values: Expectation values ordered like ``scaling_factors``.
+
+        Returns:
+            Extrapolated zero-noise expectation value.
+        """
+        if len(expectation_values) != len(self.scaling_factors):
+            raise ValueError("Expectation values must match the number of scaling factors.")
+
+        x = np.array(self.scaling_factors, dtype=float)
+        y = np.array(expectation_values, dtype=float)
+
+        if self.extrapolation_method == "linear":
+            return float(np.polyval(np.polyfit(x, y, 1), 0.0))
+
+        if self.extrapolation_method == "polynomial":
+            degree = min(self.polynomial_degree, len(self.scaling_factors) - 1)
+            return float(np.polyval(np.polyfit(x, y, degree), 0.0))
+
+        return self._extrapolate_exponential(x, y)
+
+    def mitigate(
+        self,
+        params: np.ndarray,
+        *executor_args: Any,
+        **executor_kwargs: Any,
+    ) -> float:
+        """
+        Run scaled executions and return the zero-noise extrapolated expectation value.
+        """
+        values = self.scaled_expectation_values(params, *executor_args, **executor_kwargs)
+        return self.extrapolate(values)
+
+    @staticmethod
+    def _extrapolate_exponential(
+        scaling_factors: np.ndarray,
+        expectation_values: np.ndarray,
+    ) -> float:
+        if np.any(np.isclose(expectation_values, 0.0)):
+            raise ValueError("Exponential extrapolation requires nonzero expectation values.")
+
+        sign = np.sign(expectation_values[0])
+        if not np.all(np.sign(expectation_values) == sign):
+            raise ValueError("Exponential extrapolation requires values with the same sign.")
+
+        log_values = np.log(sign * expectation_values)
+        coefficients = np.polyfit(scaling_factors, log_values, 1)
+        return float(sign * np.exp(np.polyval(coefficients, 0.0)))

--- a/tests/test_zne_mitigation.py
+++ b/tests/test_zne_mitigation.py
@@ -106,6 +106,16 @@ def test_zne_rejects_mismatched_expectation_values():
         mitigator.extrapolate([1.0])
 
 
+def test_zne_rejects_non_finite_expectation_values():
+    def executor(params, noise_scale):
+        return 1.0
+
+    mitigator = ZNEMitigator(executor, scaling_factors=[1.0, 3.0])
+
+    with pytest.raises(ValueError, match="finite real numbers"):
+        mitigator.extrapolate([1.0, np.nan])
+
+
 def test_zne_exponential_extrapolation():
     def executor(params, noise_scale):
         return 1.0
@@ -153,3 +163,6 @@ def test_zne_rejects_invalid_configuration():
 
     with pytest.raises(ValueError, match="Invalid extrapolation_method"):
         ZNEMitigator(executor, scaling_factors=[1.0, 3.0], extrapolation_method="cubic")
+
+    with pytest.raises(ValueError, match="finite real numbers"):
+        ZNEMitigator(executor, scaling_factors=[1.0, np.inf])

--- a/tests/test_zne_mitigation.py
+++ b/tests/test_zne_mitigation.py
@@ -42,6 +42,38 @@ def test_zne_polynomial_extrapolation_from_noisy_two_mode_executor():
     assert np.isclose(mitigator.mitigate(params), ideal_expectation)
 
 
+def test_zne_mitigates_noisy_perceval_linear_optical_energy():
+    circuit = pcvl.Circuit(2).add((0, 1), pcvl.BS.H())
+    input_state = pcvl.BasicState([1, 0])
+    loss_db = 0.15
+
+    def noisy_perceval_energy(params, noise_scale):
+        transmittance = 10 ** (-(loss_db * noise_scale) / 10)
+        processor = pcvl.Processor(
+            "SLOS",
+            circuit.copy(),
+            noise=pcvl.NoiseModel(transmittance=transmittance),
+        )
+        processor.with_input(input_state)
+        processor.min_detected_photons_filter(0)
+        probabilities = processor.probs()["results"]
+        return -sum(state[0] * probability for state, probability in probabilities.items())
+
+    params = np.array([])
+    ideal_energy = noisy_perceval_energy(params, noise_scale=0.0)
+    unmitigated_energy = noisy_perceval_energy(params, noise_scale=1.0)
+    mitigator = ZNEMitigator(
+        noisy_perceval_energy,
+        scaling_factors=[1.0, 2.0, 3.0],
+        extrapolation_method="exponential",
+    )
+
+    mitigated_energy = mitigator.mitigate(params)
+
+    assert abs(mitigated_energy - ideal_energy) < abs(unmitigated_energy - ideal_energy)
+    assert np.isclose(mitigated_energy, ideal_energy)
+
+
 def test_global_interferometer_folding_preserves_unitary():
     circuit = pcvl.Circuit(2) // pcvl.BS()
 

--- a/tests/test_zne_mitigation.py
+++ b/tests/test_zne_mitigation.py
@@ -1,0 +1,155 @@
+import numpy as np
+import perceval as pcvl
+import pytest
+
+from qlass.compiler import HardwareConfig
+from qlass.mitigation import ZNEMitigator, fold_global_interferometer, scale_loss_config
+
+
+def test_zne_linear_extrapolation_from_noisy_two_mode_executor():
+    params = np.array([0.25])
+    ideal_expectation = float(np.cos(params[0]))
+    noise_slope = 0.04
+    calls = []
+
+    def noisy_two_mode_executor(params, noise_scale):
+        calls.append(noise_scale)
+        return ideal_expectation + noise_slope * noise_scale
+
+    mitigator = ZNEMitigator(
+        noisy_two_mode_executor,
+        scaling_factors=[1.0, 3.0, 5.0],
+        extrapolation_method="linear",
+    )
+
+    assert np.isclose(mitigator.mitigate(params), ideal_expectation)
+    assert calls == [1.0, 3.0, 5.0]
+
+
+def test_zne_polynomial_extrapolation_from_noisy_two_mode_executor():
+    params = np.array([0.4])
+    ideal_expectation = float(np.sin(params[0]))
+
+    def noisy_two_mode_executor(params, noise_scale):
+        return ideal_expectation + 0.03 * noise_scale + 0.01 * noise_scale**2
+
+    mitigator = ZNEMitigator(
+        noisy_two_mode_executor,
+        scaling_factors=[1.0, 2.0, 3.0],
+        extrapolation_method="polynomial",
+    )
+
+    assert np.isclose(mitigator.mitigate(params), ideal_expectation)
+
+
+def test_global_interferometer_folding_preserves_unitary():
+    circuit = pcvl.Circuit(2) // pcvl.BS()
+
+    folded = fold_global_interferometer(circuit, scaling_factor=3)
+
+    assert len(list(folded)) == 3
+    assert np.allclose(folded.compute_unitary(), circuit.compute_unitary())
+
+
+def test_global_interferometer_folding_factor_one_returns_copy():
+    circuit = pcvl.Circuit(2) // pcvl.BS()
+
+    folded = fold_global_interferometer(circuit, scaling_factor=1)
+
+    assert folded is not circuit
+    assert len(list(folded)) == len(list(circuit))
+    assert np.allclose(folded.compute_unitary(), circuit.compute_unitary())
+
+
+def test_global_interferometer_folding_rejects_non_circuit():
+    with pytest.raises(TypeError, match="Perceval Circuit"):
+        fold_global_interferometer(object(), scaling_factor=3)
+
+
+def test_global_interferometer_folding_rejects_even_scaling_factor():
+    circuit = pcvl.Circuit(2) // pcvl.BS()
+
+    with pytest.raises(ValueError, match="odd integer"):
+        fold_global_interferometer(circuit, scaling_factor=2)
+
+
+def test_scale_loss_config_scales_only_photon_loss_terms():
+    config = HardwareConfig(
+        photon_loss_component_db=0.05,
+        photon_loss_waveguide_db_per_cm=0.3,
+        source_efficiency=0.8,
+        detector_efficiency=0.7,
+    )
+
+    scaled_config = scale_loss_config(config, scaling_factor=3.0)
+
+    assert np.isclose(scaled_config.photon_loss_component_db, 0.15)
+    assert np.isclose(scaled_config.photon_loss_waveguide_db_per_cm, 0.9)
+    assert scaled_config.source_efficiency == config.source_efficiency
+    assert scaled_config.detector_efficiency == config.detector_efficiency
+    assert config.photon_loss_component_db == 0.05
+    assert config.photon_loss_waveguide_db_per_cm == 0.3
+
+
+def test_scale_loss_config_rejects_subunit_scaling_factor():
+    with pytest.raises(ValueError, match="greater than or equal to 1"):
+        scale_loss_config(HardwareConfig(), scaling_factor=0.5)
+
+
+def test_zne_rejects_mismatched_expectation_values():
+    def executor(params, noise_scale):
+        return 1.0
+
+    mitigator = ZNEMitigator(executor, scaling_factors=[1.0, 3.0])
+
+    with pytest.raises(ValueError, match="match the number"):
+        mitigator.extrapolate([1.0])
+
+
+def test_zne_exponential_extrapolation():
+    def executor(params, noise_scale):
+        return 1.0
+
+    mitigator = ZNEMitigator(
+        executor,
+        scaling_factors=[1.0, 2.0, 3.0],
+        extrapolation_method="exponential",
+    )
+    ideal_expectation = 0.8
+    expectation_values = [
+        ideal_expectation * np.exp(-0.2 * scaling_factor)
+        for scaling_factor in mitigator.scaling_factors
+    ]
+
+    assert np.isclose(mitigator.extrapolate(expectation_values), ideal_expectation)
+
+
+def test_zne_exponential_extrapolation_rejects_invalid_values():
+    def executor(params, noise_scale):
+        return 1.0
+
+    mitigator = ZNEMitigator(
+        executor,
+        scaling_factors=[1.0, 2.0, 3.0],
+        extrapolation_method="exponential",
+    )
+
+    with pytest.raises(ValueError, match="nonzero"):
+        mitigator.extrapolate([1.0, 0.0, 0.2])
+
+    with pytest.raises(ValueError, match="same sign"):
+        mitigator.extrapolate([1.0, -0.5, 0.2])
+
+
+def test_zne_rejects_invalid_configuration():
+    def executor(params, noise_scale):
+        return 1.0
+
+    with pytest.raises(ValueError, match="at least two"):
+        ZNEMitigator(executor, scaling_factors=[1.0])
+
+    with pytest.raises(ValueError, match="unique"):
+        ZNEMitigator(executor, scaling_factors=[1.0, 1.0])
+
+    with pytest.raises(ValueError, match="Invalid extrapolation_method"):
+        ZNEMitigator(executor, scaling_factors=[1.0, 3.0], extrapolation_method="cubic")

--- a/tests/test_zne_mitigation.py
+++ b/tests/test_zne_mitigation.py
@@ -74,6 +74,48 @@ def test_zne_mitigates_noisy_perceval_linear_optical_energy():
     assert np.isclose(mitigated_energy, ideal_energy)
 
 
+def test_zne_mitigates_global_folded_perceval_interferometer():
+    circuit = pcvl.Circuit(2).add((0, 1), pcvl.BS.H())
+    input_state = pcvl.BasicState([1, 0])
+    component_loss = 0.05
+    folded_component_counts = []
+
+    def energy_from_processor(processor):
+        processor.with_input(input_state)
+        processor.min_detected_photons_filter(0)
+        probabilities = processor.probs()["results"]
+        return -sum(state[0] * probability for state, probability in probabilities.items())
+
+    def folded_noisy_energy(params, noise_scale):
+        folded_circuit = fold_global_interferometer(circuit, noise_scale)
+        folded_components = list(folded_circuit)
+        folded_component_counts.append(len(folded_components))
+        processor = pcvl.Processor("SLOS", 2)
+
+        for modes, component in folded_components:
+            processor.add(modes, component)
+            for mode in range(2):
+                processor.add(mode, pcvl.LC(component_loss))
+
+        return energy_from_processor(processor)
+
+    params = np.array([])
+    ideal_energy = energy_from_processor(pcvl.Processor("SLOS", circuit.copy()))
+    unmitigated_energy = folded_noisy_energy(params, noise_scale=1.0)
+    folded_component_counts.clear()
+    mitigator = ZNEMitigator(
+        folded_noisy_energy,
+        scaling_factors=[1.0, 3.0, 5.0],
+        extrapolation_method="exponential",
+    )
+
+    mitigated_energy = mitigator.mitigate(params)
+
+    assert folded_component_counts == [1, 3, 5]
+    assert abs(mitigated_energy - ideal_energy) < abs(unmitigated_energy - ideal_energy)
+    assert np.isclose(mitigated_energy, ideal_energy)
+
+
 def test_global_interferometer_folding_preserves_unitary():
     circuit = pcvl.Circuit(2) // pcvl.BS()
 


### PR DESCRIPTION
Closes #181

### Summary

This PR adds Zero Noise Extrapolation support under `qlass.mitigation`:

- Adds `ZNEMitigator` in `qlass/mitigation/zne.py` for scaled expectation-value execution and zero-noise extrapolation.
- Supports `linear`, `polynomial`, and `exponential` extrapolation.
- Adds `fold_global_interferometer()` for global folding of deterministic Perceval linear optical circuits as `U (U† U)^n`.
- Adds `scale_loss_config()` to scale `HardwareConfig` photon-loss parameters in dB without mutating the original config.
- Exports the new ZNE utilities from `qlass.mitigation`.
- Adds API documentation for `qlass.mitigation`.
- Adds unit tests covering extrapolation, folding, loss scaling, and invalid inputs.

### Verification

```bash
UV_PROJECT_ENVIRONMENT=.venv-wsl uv run --group lint ruff check .
UV_PROJECT_ENVIRONMENT=.venv-wsl uv run --group lint ruff format --check .
UV_PROJECT_ENVIRONMENT=.venv-wsl uv run --group type-check mypy src/qlass
UV_PROJECT_ENVIRONMENT=.venv-wsl uv run --group test pytest --cov -q
```

Result:

```text
99 passed
src/qlass/mitigation/zne.py: 100% coverage
TOTAL coverage: 94%
```

Docs build was also checked:

```bash
UV_PROJECT_ENVIRONMENT=.venv-wsl uv run --group docs -m sphinx -T -b html -d docs/_build/doctrees docs docs/_build/html
```

The build succeeded; existing docutils warnings remain outside this change.

### Notes

The noisy 2-mode ZNE tests use deterministic expectation-value models rather than stochastic shot-based sampling. This keeps the tests stable while verifying the intended ZNE behavior: scaled execution, linear/polynomial extrapolation to the zero-noise intercept, global interferometer folding, and photon-loss configuration scaling.

### AI Transparency

I used OpenAI Codex to help inspect the repository patterns, draft the implementation/tests, and run local verification. I manually reviewed the math, code paths, tests, and command outputs before preparing this PR.