### PR TITLE
Add circuit visualization via `draw_circuit` and `VQE.draw_ansatz`

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -250,6 +250,46 @@ Using photonic unitaries with dual-rail encoding and post-selection:
    
    vqe_energy = vqe.run(max_iterations=100, verbose=True)
 
+Circuit Visualization
+~~~~~~~~~~~~~~~~~~~~~
+
+Inspecting the compiled photonic circuit for a VQE ansatz before or after optimization:
+
+.. code-block:: python
+
+   import numpy as np
+   from qlass import draw_circuit
+   from qlass.vqe import VQE, le_ansatz
+   from qlass.quantum_chemistry import LiH_hamiltonian
+   from perceval.algorithm import Sampler
+   import warnings
+   warnings.filterwarnings('ignore')
+
+   # Number of qubits
+   num_qubits = 2
+   params = np.array([0.1, 0.2, 0.3, 0.4])
+
+   # Draw the ansatz processor directly
+   processor = le_ansatz(params, "II")
+   draw_circuit(processor, output_format="mpl", skin="phys")
+   draw_circuit(processor, output_format="html", save_path="le_ansatz.html")
+
+   # Define an executor function that uses the linear entangled ansatz
+   def executor(params, pauli_string):
+       processor = le_ansatz(params, pauli_string)
+       sampler = Sampler(processor)
+       samples = sampler.samples(100)
+       return samples
+
+   # Visualize via VQE.draw_ansatz (pass ansatz_fn when executor returns samples)
+   hamiltonian = LiH_hamiltonian(num_electrons=2, num_orbitals=1)
+   vqe = VQE(
+       hamiltonian=hamiltonian,
+       executor=executor,
+       num_params=2 * num_qubits,
+   )
+   vqe.draw_ansatz(params, ansatz_fn=le_ansatz, output_format="html", save_path="vqe_ansatz.html")
+
 Ensemble-VQE (e-VQE)
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -315,6 +355,48 @@ Using DFT-based Kohn-Sham Hamiltonians:
    )
    
    vqe_energy = vqe.run(max_iterations=50, verbose=True)
+
+Bose-Hubbard VQE
+~~~~~~~~~~~~~~~~
+
+Computing the ground-state energy of a Bose-Hubbard dimer using sampling-based
+``loss_function_bose_hubbard``. The executor must handle two measurement types:
+
+* ``"identity"`` — sample Fock occupation numbers in the computational basis.
+* ``"hop", p, q`` — apply ``rotate_modes(p, q, circuit)`` then sample; modes ``p``
+  and ``q`` must be consecutive.
+
+.. code-block:: python
+
+   import numpy as np
+   from openfermion.ops import BosonOperator
+   from perceval.algorithm import Sampler
+
+   from qlass.utils import loss_function_bose_hubbard, rotate_modes
+
+   # 2-site Bose-Hubbard dimer: H = -t(a†_0 a_1 + h.c.) - mu*(n_0+n_1) + U/2*sum n_i(n_i-1)
+   t, mu, U = 1.0, 0.5, 4.0
+   H = (
+       BosonOperator("0^ 1", -t) + BosonOperator("1^ 0", -t)
+       + BosonOperator("0^ 0", -mu) + BosonOperator("1^ 1", -mu)
+       + BosonOperator("0^ 0^ 0 0", U / 2) + BosonOperator("1^ 1^ 1 1", U / 2)
+   )
+
+   def build_ansatz(params):
+       """Return a Perceval processor for the variational state."""
+       ...  # build and return processor
+
+   def executor(params, measurement_type, *modes):
+       processor = build_ansatz(params)
+       if measurement_type == "hop":
+           p, q = modes
+           rotate_modes(p, q, processor.linear_circuit())
+       sampler = Sampler(processor)
+       return sampler.samples(10_000)
+
+   params = np.random.rand(4)
+   energy = loss_function_bose_hubbard(params, H, executor)
+   print(f"Energy: {energy:.6f}")
 
 Working with Molecular Hamiltonians
 -----------------------------------

--- a/docs/qlass.utils.rst
+++ b/docs/qlass.utils.rst
@@ -12,10 +12,14 @@ Key Features
 - ``loss_function_matrix``: Loss function for qubit unitary-based VQE
 - ``loss_function_photonic_unitary``: Loss function for photonic unitaries with post-selection
 - ``e_vqe_loss_function``: Ensemble-VQE loss function supporting multiple states
+- ``loss_function_bose_hubbard``: Sampling-based loss function for Bose-Hubbard Hamiltonians
 
 **Utilities**
 
 - ``linear_circuit_to_unitary``: Converts Perceval linear circuits to unitary matrices
+- ``draw_circuit``: Visualizes Perceval Processor or Circuit objects using Perceval's
+  ``pdisplay`` interface (supports ``mpl``, ``html``, ``latex``, and ``text`` formats)
+- ``rotate_modes``: Appends a 50/50 beam splitter on a consecutive mode pair for hopping-term measurement
 - ``DataCollector``: Collects and stores energy data during ensemble-VQE optimization
 
   - ``loss_data``: List of cost function values

--- a/docs/qlass.vqe.rst
+++ b/docs/qlass.vqe.rst
@@ -31,6 +31,12 @@ The VQE class supports three executor types to handle different abstraction leve
   - ``method="DFT"``: Density functional theory :cite:p:`kohn1965self`
   - Compatible with both VQE and e-VQE costs
 
+**Circuit Visualization**
+
+- ``VQE.draw_ansatz``: Visualizes the compiled photonic circuit for a given set of
+  variational parameters outside the optimization loop
+- ``draw_circuit``: Standalone utility for drawing Perceval Processor or Circuit objects
+
 VQE Class
 ---------
 

--- a/examples/draw_circuit_example.py
+++ b/examples/draw_circuit_example.py
@@ -1,0 +1,109 @@
+"""
+Example demonstrating circuit visualization with draw_circuit and VQE.draw_ansatz.
+"""
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+from perceval.algorithm import Sampler
+
+from qlass.quantum_chemistry import LiH_hamiltonian
+from qlass.utils import draw_circuit
+from qlass.vqe import VQE, le_ansatz
+
+warnings.simplefilter("ignore")
+warnings.filterwarnings("ignore")
+
+
+# Define an executor function that uses the linear entangled ansatz
+def executor(params, pauli_string):
+    """
+    Executor function that creates a processor with the le_ansatz.
+    """
+    processor = le_ansatz(params, pauli_string)
+    sampler = Sampler(processor)
+    samples = sampler.samples(100)
+    return samples
+
+
+def main():
+    # Number of qubits
+    num_qubits = 2
+
+    # Variational parameters and measurement basis
+    params = np.array([0.1, 0.2, 0.3, 0.4])
+    pauli_string = "II"
+
+    # Output directory for saved figures
+    output_dir = Path(__file__).resolve().parent / "circuit_outputs"
+    output_dir.mkdir(exist_ok=True)
+
+    # Build the linear entangled ansatz processor
+    processor = le_ansatz(params, pauli_string)
+
+    # Save circuit visualizations in multiple formats
+    print("Saving circuit visualizations...")
+    draw_circuit(
+        processor,
+        output_format="mpl",
+        skin="phys",
+        save_path=str(output_dir / "le_ansatz_phys.png"),
+    )
+    print(f"  {output_dir / 'le_ansatz_phys.png'}")
+
+    draw_circuit(
+        processor,
+        output_format="html",
+        skin="symb",
+        save_path=str(output_dir / "le_ansatz_symb.html"),
+    )
+    print(f"  {output_dir / 'le_ansatz_symb.html'}")
+
+    draw_circuit(
+        processor,
+        output_format="mpl",
+        skin="debug",
+        compact=True,
+        save_path=str(output_dir / "le_ansatz_debug.png"),
+    )
+    print(f"  {output_dir / 'le_ansatz_debug.png'}")
+
+    draw_circuit(
+        processor,
+        output_format="text",
+        skin="symb",
+        save_path=str(output_dir / "le_ansatz_symb.txt"),
+    )
+    print(f"  {output_dir / 'le_ansatz_symb.txt'}")
+
+    # Display the circuit in the terminal
+    print("\nText preview (symb skin):")
+    draw_circuit(processor, output_format="text", skin="symb")
+
+    # Generate a 2-qubit Hamiltonian for LiH
+    hamiltonian = LiH_hamiltonian(num_electrons=2, num_orbitals=1)
+
+    # Initialize the VQE solver with the custom executor
+    vqe = VQE(
+        hamiltonian=hamiltonian,
+        executor=executor,
+        num_params=2 * num_qubits,  # Number of parameters in the linear entangled ansatz
+    )
+
+    # Visualize the ansatz via VQE.draw_ansatz (pass ansatz_fn when executor returns samples)
+    vqe_path = output_dir / "vqe_draw_ansatz.html"
+    print(f"\nSaving VQE.draw_ansatz output to {vqe_path} ...")
+    vqe.draw_ansatz(
+        params,
+        ansatz_fn=le_ansatz,
+        output_format="html",
+        skin="phys",
+        save_path=str(vqe_path),
+    )
+
+    print(f"\nCircuit figures saved in {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qlass/__init__.py
+++ b/src/qlass/__init__.py
@@ -14,6 +14,7 @@ from .quantum_chemistry.hamiltonians import (
 )
 
 # export from utils module
+from .utils.draw_circuit import draw_circuit
 from .utils.utils import e_vqe_loss_function, loss_function, rotate_qubits
 
 # export from vqe module
@@ -35,6 +36,7 @@ __all__ = [
     "loss_function",
     "e_vqe_loss_function",
     "rotate_qubits",
+    "draw_circuit",
     "ResourceAwareCompiler",
     "HardwareConfig",
     "generate_report",

--- a/src/qlass/utils/__init__.py
+++ b/src/qlass/utils/__init__.py
@@ -1,3 +1,4 @@
+from .draw_circuit import draw_circuit
 from .utils import (
     compute_energy,
     compute_expectation_value_from_unitary,
@@ -32,4 +33,5 @@ __all__ = [
     "logical_state_to_modes",
     "photon_to_qubit_unitary",
     "loss_function_photonic_unitary",
+    "draw_circuit",
 ]

--- a/src/qlass/utils/draw_circuit.py
+++ b/src/qlass/utils/draw_circuit.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+import perceval as pcvl
+from perceval.components import Processor
+from perceval.rendering.circuit import DebugSkin, PhysSkin, SymbSkin
+from perceval.rendering.format import Format
+
+_OUTPUT_FORMATS = {
+    "mpl": Format.MPLOT,
+    "html": Format.HTML,
+    "latex": Format.LATEX,
+    "text": Format.TEXT,
+}
+
+_SKIN_CLASSES = {
+    "phys": PhysSkin,
+    "symb": SymbSkin,
+    "debug": DebugSkin,
+}
+
+
+def _resolve_circuit(circuit_or_processor: Processor | pcvl.Circuit) -> pcvl.Circuit:
+    if isinstance(circuit_or_processor, pcvl.Circuit):
+        return circuit_or_processor
+    if isinstance(circuit_or_processor, Processor):
+        return circuit_or_processor.linear_circuit()
+    raise TypeError(
+        f"Expected a Perceval Processor or Circuit, got {type(circuit_or_processor).__name__}."
+    )
+
+
+def draw_circuit(
+    circuit_or_processor: Processor | pcvl.Circuit,
+    output_format: str = "mpl",
+    skin: str = "phys",
+    compact: bool = False,
+    save_path: str | None = None,
+    backend: str = "perceval",
+) -> None:
+    """
+    Draw a linear optical circuit.
+
+    Wraps Perceval's ``pdisplay`` and ``pdisplay_to_file`` with sensible defaults
+    for inspecting photonic circuits outside the VQE optimization loop.
+
+    Args:
+        circuit_or_processor (Processor | pcvl.Circuit): Perceval processor or circuit
+        output_format (str): One of ``"mpl"``, ``"html"``, ``"latex"``, ``"text"``
+        skin (str): One of ``"phys"``, ``"symb"``, ``"debug"``
+        compact (bool): If True, use compact display mode
+        save_path (str, optional): If provided, save the figure to this file path
+        backend (str): Photonic backend to use for rendering. Currently only
+            ``"perceval"`` is supported
+    """
+    if backend != "perceval":
+        raise NotImplementedError(
+            f"Backend '{backend}' is not supported yet. Only 'perceval' is available."
+        )
+
+    if output_format not in _OUTPUT_FORMATS:
+        raise ValueError(
+            f"Invalid output_format: {output_format!r}. Must be one of {sorted(_OUTPUT_FORMATS)}."
+        )
+    if skin not in _SKIN_CLASSES:
+        raise ValueError(f"Invalid skin: {skin!r}. Must be one of {sorted(_SKIN_CLASSES)}.")
+
+    circuit = _resolve_circuit(circuit_or_processor)
+    fmt = _OUTPUT_FORMATS[output_format]
+    skin_instance = _SKIN_CLASSES[skin](compact_display=compact)
+
+    if save_path is not None:
+        pcvl.pdisplay_to_file(circuit, save_path, output_format=fmt, skin=skin_instance)
+    else:
+        pcvl.pdisplay(circuit, output_format=fmt, skin=skin_instance)
+
+
+def resolve_executor_circuit(result: Any) -> Processor | pcvl.Circuit:
+    """
+    Extract a Perceval Processor or Circuit from an executor return value.
+
+    Args:
+        result (Any): Value returned by a VQE executor
+
+    Returns:
+        Processor | pcvl.Circuit: Object suitable for :func:`draw_circuit`
+
+    Raises:
+        TypeError: If the executor result cannot be visualized as a circuit
+    """
+    if isinstance(result, (Processor, pcvl.Circuit)):
+        return result
+    if hasattr(result, "linear_circuit") and callable(result.linear_circuit):
+        return result
+    raise TypeError(
+        "Executor did not return a Perceval Processor or Circuit. "
+        "Pass ansatz_fn to draw_ansatz (e.g. ansatz_fn=le_ansatz) or call "
+        "draw_circuit directly on the ansatz output."
+    )

--- a/src/qlass/vqe/vqe.py
+++ b/src/qlass/vqe/vqe.py
@@ -5,7 +5,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.optimize import OptimizeResult, minimize
 
-from qlass.utils import e_vqe_loss_function, loss_function
+from qlass.utils import draw_circuit, e_vqe_loss_function, loss_function
+from qlass.utils.draw_circuit import resolve_executor_circuit
 from qlass.utils.utils import DataCollector
 
 
@@ -292,6 +293,36 @@ class VQE:
         if self.optimization_result is None:
             raise ValueError("VQE optimization has not been run yet.")
         return np.asarray(self.optimization_result.x)
+
+    def draw_ansatz(
+        self,
+        params: np.ndarray,
+        pauli_string: str | None = None,
+        *,
+        ansatz_fn: Callable | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Visualize the ansatz circuit for a specific set of parameters.
+
+        Args:
+            params (np.ndarray): Variational parameters for the ansatz
+            pauli_string (str, optional): Pauli string for measurement basis rotation.
+                Defaults to all identity (``"I" * num_qubits``)
+            ansatz_fn (Callable, optional): Callable ``(params, pauli_string) -> Processor``
+                used to build the circuit. Required when the executor returns samples
+                rather than a Perceval object (e.g. pass ``le_ansatz``)
+            **kwargs: Additional keyword arguments forwarded to :func:`draw_circuit`
+        """
+        if pauli_string is None:
+            pauli_string = "I" * self.num_qubits
+
+        if ansatz_fn is not None:
+            circuit_or_processor = ansatz_fn(params, pauli_string)
+        else:
+            circuit_or_processor = resolve_executor_circuit(self.executor(params, pauli_string))
+
+        draw_circuit(circuit_or_processor, **kwargs)
 
     def plot_convergence(self, exact_energy: float | None = None) -> None:
         """

--- a/tests/test_draw_circuit.py
+++ b/tests/test_draw_circuit.py
@@ -1,0 +1,151 @@
+import warnings
+from unittest.mock import patch
+
+import numpy as np
+import perceval as pcvl
+import pytest
+
+from qlass.utils import draw_circuit
+from qlass.utils.draw_circuit import _OUTPUT_FORMATS, resolve_executor_circuit
+from qlass.vqe import VQE, le_ansatz
+
+warnings.simplefilter("ignore")
+warnings.filterwarnings("ignore")
+
+
+@pytest.fixture
+def two_qubit_processor():
+    """Provides a 2-qubit linear entangled ansatz processor."""
+    params = np.array([0.1, 0.2, 0.3, 0.4])
+    return le_ansatz(params, "II")
+
+
+@pytest.mark.parametrize("output_format", ["mpl", "html", "latex", "text"])
+@patch("qlass.utils.draw_circuit.pcvl.pdisplay")
+def test_draw_circuit_output_formats(mock_pdisplay, two_qubit_processor, output_format):
+    """Tests that draw_circuit runs for each supported output format."""
+    draw_circuit(two_qubit_processor, output_format=output_format)
+    mock_pdisplay.assert_called_once()
+    _, call_kwargs = mock_pdisplay.call_args
+    assert call_kwargs["output_format"] == _OUTPUT_FORMATS[output_format]
+
+
+@pytest.mark.parametrize("skin", ["phys", "symb", "debug"])
+@patch("qlass.utils.draw_circuit.pcvl.pdisplay")
+def test_draw_circuit_skins(mock_pdisplay, two_qubit_processor, skin):
+    """Tests that draw_circuit accepts each supported skin."""
+    draw_circuit(two_qubit_processor, skin=skin)
+    _, call_kwargs = mock_pdisplay.call_args
+    assert call_kwargs["skin"].__class__.__name__.lower().startswith(skin[:4])
+
+
+@patch("qlass.utils.draw_circuit.pcvl.pdisplay")
+def test_draw_circuit_accepts_circuit(mock_pdisplay, two_qubit_processor):
+    """Tests that draw_circuit accepts a Perceval Circuit directly."""
+    circuit = two_qubit_processor.linear_circuit()
+    draw_circuit(circuit, output_format="text")
+    mock_pdisplay.assert_called_once()
+    assert isinstance(mock_pdisplay.call_args[0][0], pcvl.Circuit)
+
+
+@patch("qlass.utils.draw_circuit.pcvl.pdisplay_to_file")
+def test_draw_circuit_save_path(mock_pdisplay_to_file, two_qubit_processor, tmp_path):
+    """Tests that draw_circuit saves figures when save_path is provided."""
+    save_path = tmp_path / "circuit.png"
+    draw_circuit(two_qubit_processor, save_path=str(save_path))
+    mock_pdisplay_to_file.assert_called_once()
+    assert mock_pdisplay_to_file.call_args[0][1] == str(save_path)
+
+
+@patch("qlass.utils.draw_circuit.pcvl.pdisplay")
+def test_draw_circuit_compact(mock_pdisplay, two_qubit_processor):
+    """Tests that compact mode is forwarded to the Perceval skin."""
+    draw_circuit(two_qubit_processor, compact=True)
+    _, call_kwargs = mock_pdisplay.call_args
+    assert call_kwargs["skin"]._compact is True
+
+
+def test_draw_circuit_invalid_output_format(two_qubit_processor):
+    """Tests that an invalid output format raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid output_format"):
+        draw_circuit(two_qubit_processor, output_format="svg")
+
+
+def test_draw_circuit_invalid_skin(two_qubit_processor):
+    """Tests that an invalid skin raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid skin"):
+        draw_circuit(two_qubit_processor, skin="neon")
+
+
+def test_draw_circuit_unsupported_backend(two_qubit_processor):
+    """Tests that unsupported backends raise NotImplementedError."""
+    with pytest.raises(NotImplementedError, match="piquasso"):
+        draw_circuit(two_qubit_processor, backend="piquasso")
+
+
+def test_resolve_executor_circuit_processor(two_qubit_processor):
+    """Tests resolve_executor_circuit with a Processor input."""
+    assert resolve_executor_circuit(two_qubit_processor) is two_qubit_processor
+
+
+def test_resolve_executor_circuit_circuit(two_qubit_processor):
+    """Tests resolve_executor_circuit with a Circuit input."""
+    circuit = two_qubit_processor.linear_circuit()
+    assert resolve_executor_circuit(circuit) is circuit
+
+
+def test_resolve_executor_circuit_invalid():
+    """Tests that invalid executor results raise TypeError."""
+    with pytest.raises(TypeError, match="Executor did not return"):
+        resolve_executor_circuit({"counts": {"00": 500}})
+
+
+@patch("qlass.vqe.vqe.draw_circuit")
+def test_vqe_draw_ansatz_with_ansatz_fn(mock_draw_circuit):
+    """Tests VQE.draw_ansatz when ansatz_fn is provided."""
+    hamiltonian = {"II": -0.5, "ZZ": 1.0}
+    vqe = VQE(hamiltonian=hamiltonian, executor=lambda p, s: {"counts": {"00": 1}}, num_params=4)
+    params = np.zeros(4)
+
+    vqe.draw_ansatz(params, ansatz_fn=le_ansatz, output_format="text")
+
+    mock_draw_circuit.assert_called_once()
+    processor = mock_draw_circuit.call_args[0][0]
+    assert hasattr(processor, "linear_circuit")
+
+
+@patch("qlass.vqe.vqe.draw_circuit")
+def test_vqe_draw_ansatz_default_pauli_string(mock_draw_circuit):
+    """Tests that VQE.draw_ansatz forwards kwargs to draw_circuit."""
+    hamiltonian = {"II": -0.5, "ZZ": 1.0}
+    vqe = VQE(hamiltonian=hamiltonian, executor=lambda p, s: {"counts": {"00": 1}}, num_params=4)
+    params = np.zeros(4)
+
+    vqe.draw_ansatz(params, ansatz_fn=le_ansatz)
+
+    assert mock_draw_circuit.call_args[1] == {}
+
+
+@patch("qlass.vqe.vqe.draw_circuit")
+def test_vqe_draw_ansatz_executor_returns_processor(mock_draw_circuit):
+    """Tests VQE.draw_ansatz when the executor returns a Processor."""
+    params = np.zeros(4)
+
+    def executor(p, pauli_string):
+        return le_ansatz(p, pauli_string)
+
+    hamiltonian = {"II": -0.5, "ZZ": 1.0}
+    vqe = VQE(hamiltonian=hamiltonian, executor=executor, num_params=4)
+
+    vqe.draw_ansatz(params)
+
+    mock_draw_circuit.assert_called_once()
+
+
+def test_vqe_draw_ansatz_sampling_executor_raises():
+    """Tests that sampling executors require ansatz_fn."""
+    hamiltonian = {"II": -0.5, "ZZ": 1.0}
+    vqe = VQE(hamiltonian=hamiltonian, executor=lambda p, s: {"counts": {"00": 1}}, num_params=4)
+
+    with pytest.raises(TypeError, match="Executor did not return"):
+        vqe.draw_ansatz(np.zeros(4))


### PR DESCRIPTION
Added `draw_circuit` util — Perceval `pdisplay` wrapper (mpl/html/latex/text; phys/symb/debug skins; save_path) and  `VQE.draw_ansatz` inspect ansatz outside optimization loop; `ansatz_fn` for sampling executors.


Closes: #176