### PR TITLE
Fix excited-state preparation in Bitstring_initial_states

### DIFF
--- a/src/qlass/vqe/ansatz.py
+++ b/src/qlass/vqe/ansatz.py
@@ -6,7 +6,6 @@ from perceval.components import Processor
 from perceval.utils import NoiseModel
 from qiskit import QuantumCircuit, transpile
 from qiskit.circuit.library import n_local
-from qiskit.quantum_info import Statevector
 
 from qlass.compiler import compile
 from qlass.utils import rotate_qubits
@@ -281,7 +280,8 @@ def Bitstring_initial_states(
     - See `https://scipost.org/SciPostPhys.14.3.055` for details on the DFT mapping.
     """
     initial_circuits = []
-    num_qubits = len(lp) // 2
+    # n_local(..., reps=layers) has num_qubits * (layers + 1) parameters
+    num_qubits = len(lp) // (layers + 1)
     for _i in range(n_states):
         initial_circuits += [QuantumCircuit(num_qubits)]
     """Initial states"""
@@ -308,23 +308,17 @@ def Bitstring_initial_states(
     """Assign parameters"""
     circuits = [c.assign_parameters(lp) for c in circuits]
 
-    intial_states = []
-    for c in range(len(initial_circuits)):
-        sv = Statevector.from_instruction(initial_circuits[c])
-        index = list(sv.data).index(1 + 0j)  # position of the "1"
-        bitstring = format(index, f"0{sv.num_qubits}b")
-        bits_list = [int(b) for b in bitstring]
-        intial_states.append(pcvl.LogicalState(bits_list))
-
     ansatz_transpiled = [
         transpile(c, basis_gates=["u3", "cx"], optimization_level=3) for c in circuits
     ]
 
     ansatz_rot = [rotate_qubits(pauli_string, at.copy()) for at in ansatz_transpiled]
 
+    # The X-gate state preparation is already part of each circuit, so every
+    # processor takes the dual-rail-encoded |0...0> as photonic input.
+    input_state = pcvl.LogicalState([0] * num_qubits)
     processors = [
-        compile(ar, input_state=st, noise_model=noise_model)
-        for ar, st in zip(ansatz_rot, intial_states, strict=False)
+        compile(ar, input_state=input_state, noise_model=noise_model) for ar in ansatz_rot
     ]
     if cost == "VQE":
         return processors[0]

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -567,6 +567,34 @@ def test_Bitstring_initial_states():
         )
 
 
+def test_Bitstring_initial_states_prepares_correct_excited_state():
+    """Regression test for issue #208.
+
+    With zero parameters the ansatz reduces to the X-gate preparation followed
+    by CX gates: state index 1 applies X on qubit 0, and cx(0, 1) then flips
+    qubit 1, giving |11> whose dual-rail encoding is |0,1,0,1>. The previous
+    implementation prepared the basis state twice (X gates in the circuit plus
+    a non-vacuum photonic input) with reversed bit order, producing |0,1,1,0>.
+    """
+    procs = Bitstring_initial_states(
+        layers=1, n_states=2, lp=np.zeros(4), pauli_string="II", cost="e-VQE"
+    )
+    samples = Sampler(procs[1]).samples(50)["results"]
+    assert len(samples) > 0
+    expected = pcvl.BasicState([0, 1, 0, 1])
+    assert all(s == expected for s in samples), f"got {samples[0]}, expected {expected}"
+
+
+def test_Bitstring_initial_states_multiple_layers():
+    """Regression test for issue #208: qubit-count inference must account for
+    layers — n_local(reps=layers) has num_qubits * (layers + 1) parameters."""
+    proc = Bitstring_initial_states(
+        layers=2, n_states=1, lp=np.zeros(6), pauli_string="II", cost="VQE"
+    )
+    assert isinstance(proc, pcvl.Processor)
+    assert proc.m == 4  # 2 qubits -> 4 dual-rail modes
+
+
 def test_CSF_initial_states():
     from qlass.vqe.ansatz import CSF_initial_states
 


### PR DESCRIPTION
Fixes #208.

Three independent bugs made ensemble-VQE excited-state energies wrong for every state except the ground state:

1. **Double state preparation**: the X-gate prep circuits were composed into the compiled circuit *and* the same basis state was fed again as the photonic input via `pcvl.LogicalState(bits_list)`.
2. **Endianness**: `bits_list` was built in big-endian order relative to qiskit qubit indices. Net effect: for state index 1 on two qubits, the sampled output was `|0,1,1,0>` instead of the intended `|0,1,0,1>`.
3. **Qubit-count inference**: `num_qubits = len(lp) // 2` is only correct for `layers=1`; `n_local(reps=layers)` has `num_qubits * (layers + 1)` parameters, so any other depth failed in `assign_parameters`.

The fix feeds the dual-rail `|0...0>` as input (the X gates already prepare the state), corrects the parameter-count formula, and drops the fragile `Statevector` round-trip that located the basis state via exact float comparison.

**Tests**: a regression test samples the photonic output of an excited state and checks it against the hand-derived dual-rail encoding, plus a `layers=2` construction test. Both fail on the previous implementation; full suite, ruff, and mypy pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)