### PR TITLE
Fix complex conjugation in Lanczos re-orthogonalization

### DIFF
--- a/src/qlass/quantum_chemistry/classical_solution.py
+++ b/src/qlass/quantum_chemistry/classical_solution.py
@@ -73,10 +73,9 @@ def brute_force_minimize(H: dict[str, float]) -> float:
     """
 
     H_matrix = hamiltonian_matrix(H)
-    l0 = np.linalg.eigvals(H_matrix)
-    l0.sort()
+    eigenvalues = np.linalg.eigvalsh(H_matrix)
 
-    return float(l0[0].real)
+    return float(eigenvalues[0])
 
 
 def _lanczos_impl(A: np.ndarray, v_init: np.ndarray, m: int) -> tuple[np.ndarray, np.ndarray]:
@@ -113,7 +112,7 @@ def _lanczos_impl(A: np.ndarray, v_init: np.ndarray, m: int) -> tuple[np.ndarray
         # Explicitly make the new vector orthogonal to all previous vectors
         # This is the key to fixing numerical stability issues.
         for i in range(j):
-            v -= np.dot(v.conj(), V[i, :]) * V[i, :]
+            v -= np.dot(V[i, :].conj(), v) * V[i, :]
         v /= np.linalg.norm(v)  # Re-normalize after correction
         # --- End of Re-orthogonalization ---
 
@@ -142,17 +141,18 @@ lanczos: Callable[[np.ndarray, np.ndarray, int], tuple[np.ndarray, np.ndarray]]
 lanczos = njit(_lanczos_impl) if not DISABLE_JIT else _lanczos_impl
 
 
-def eig_decomp_lanczos(R: np.ndarray, n: int = 1, m: int = 100) -> np.ndarray:
+def eig_decomp_lanczos(R: np.ndarray, n: int | None = None, m: int = 100) -> np.ndarray:
     """
     Compute the eigenvalues of a matrix using the Lanczos algorithm.
 
     Args:
         R (np.ndarray): Matrix to compute the eigenvalues of
-        n (int): Number of eigenvalues to compute
+        n (Optional[int]): Number of smallest eigenvalues to return.
+            If None (default), all Ritz values are returned.
         m (int): Number of iterations
 
     Returns:
-        np.ndarray: Eigenvalues of the matrix
+        np.ndarray: Eigenvalues of the matrix, in ascending order
 
     """
 
@@ -162,4 +162,4 @@ def eig_decomp_lanczos(R: np.ndarray, n: int = 1, m: int = 100) -> np.ndarray:
     T, V = lanczos(R, v0, m)
     esT, _ = np.linalg.eigh(T)
 
-    return esT
+    return esT if n is None else esT[:n]

--- a/tests/test_quantum_chemistry.py
+++ b/tests/test_quantum_chemistry.py
@@ -141,6 +141,49 @@ def test_lanczos_tridiagonalization():
     assert np.allclose(lhs, rhs), "Tridiagonal matrix T does not satisfy the Lanczos relation"
 
 
+def test_lanczos_reorthogonalization_complex_hermitian():
+    """Regression test for issue #212.
+
+    The re-orthogonalization step subtracted conj(<V_i, v>) V_i instead of
+    <V_i, v> V_i — correct for real matrices, wrong for complex Hermitian
+    ones. The error only shows once orthogonality actually degrades, so use
+    a genuinely complex Hermitian matrix with a clustered spectrum: with the
+    wrong conjugation the Lanczos basis loses orthonormality entirely
+    (max deviation ~0.7) and the smallest Ritz value is off by ~0.6.
+    """
+    rng = np.random.default_rng(7)
+    dim = 120
+    spectrum = np.concatenate(
+        [np.linspace(-2, -1.99, 20), np.linspace(0, 1, 80), np.linspace(9, 10, 20)]
+    )
+    Q, _ = np.linalg.qr(rng.standard_normal((dim, dim)) + 1j * rng.standard_normal((dim, dim)))
+    A = Q @ np.diag(spectrum) @ Q.conj().T
+    v_init = (rng.standard_normal(dim) + 1j * rng.standard_normal(dim)).astype(np.complex128)
+
+    m = 60
+    T, V = lanczos(A, v_init, m)
+
+    assert np.allclose(V @ V.conj().T, np.eye(m), atol=1e-8), "Lanczos basis lost orthonormality"
+    smallest_ritz = np.linalg.eigvalsh(T)[0].real
+    assert np.isclose(smallest_ritz, spectrum.min(), atol=1e-4)
+
+
+def test_eig_decomp_lanczos_returns_n_smallest():
+    """eig_decomp_lanczos(R, n=k) returns the k smallest eigenvalues."""
+    dim = 8
+    np.random.seed(42)
+    random_real_matrix = np.random.rand(dim, dim)
+    hermitian_matrix = ((random_real_matrix + random_real_matrix.T.conj()) / 2).astype(
+        np.complex128
+    )
+
+    two_smallest = eig_decomp_lanczos(hermitian_matrix, n=2)
+
+    assert two_smallest.shape == (2,)
+    exact = np.linalg.eigvalsh(hermitian_matrix)
+    assert np.allclose(two_smallest, exact[:2], atol=1e-3)
+
+
 def test_lanczos_early_exit():
     """
     Tests the early exit condition of the lanczos function when beta becomes zero.


### PR DESCRIPTION
Fixes #212.

`_lanczos_impl` re-orthogonalized with `np.dot(v.conj(), V[i])`, which subtracts `conj(<V_i, v>) V_i` instead of `<V_i, v> V_i` — a no-op for real matrices, wrong for complex Hermitian ones (which `hamiltonian_matrix` produces whenever the Hamiltonian has Y terms). The bug only manifests when orthogonality actually degrades, which is why the existing small-matrix test never caught it. Measured on a 120×120 complex Hermitian matrix with a clustered spectrum (m=60):

| | ground-state error | basis orthogonality error |
|---|---|---|
| before | 6.2e-1 | 7.5e-1 |
| after | 1.0e-7 | 6.7e-16 |

Also in this PR (same module, from the #219 checklist):
- `brute_force_minimize` now uses `np.linalg.eigvalsh` instead of `eigvals` + lexicographic complex sort.
- `eig_decomp_lanczos` honors its documented `n` parameter (previously accepted and ignored). Default `n=None` preserves the old return-all behavior; `n=k` returns the k smallest eigenvalues.

Both new tests fail on the previous implementation; full quantum-chemistry suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)