### PR TITLE
Reject non-power-of-two chain lengths in Hchain_KS_hamiltonian

### DIFF
--- a/src/qlass/quantum_chemistry/hamiltonians.py
+++ b/src/qlass/quantum_chemistry/hamiltonians.py
@@ -386,8 +386,9 @@ def Hchain_KS_hamiltonian(
     Parameters
     ----------
     n_hydrogens : int, optional
-        Number of hydrogen atoms in the linear chain. Must be an even integer.
-        Default is 2.
+        Number of hydrogen atoms in the linear chain. Must be a power of two
+        (2, 4, 8, ...), since the n_hydrogens x n_hydrogens Fock matrix is
+        mapped onto log2(n_hydrogens) qubits. Default is 2.
     R : float, optional
         Bond length between adjacent hydrogen atoms in angstroms. Default is 1.2.
 
@@ -415,6 +416,13 @@ def Hchain_KS_hamiltonian(
 
     """
     from pyscf import gto, scf
+
+    if n_hydrogens < 2 or (n_hydrogens & (n_hydrogens - 1)) != 0:
+        raise ValueError(
+            f"n_hydrogens must be a power of two (2, 4, 8, ...), got {n_hydrogens}. "
+            f"The {n_hydrogens}x{n_hydrogens} Fock matrix is mapped onto "
+            "log2(n_hydrogens) qubits; any other size would be silently truncated."
+        )
 
     geometry = []
     numberof_qubits = int(np.log2(n_hydrogens))

--- a/tests/test_quantum_chemistry.py
+++ b/tests/test_quantum_chemistry.py
@@ -335,6 +335,18 @@ def test_Hchain_KS_hamiltonian(monkeypatch):
     assert -2.0 < mo_energy[0] < 0.0
 
 
+def test_Hchain_KS_hamiltonian_rejects_non_power_of_two():
+    """Regression test for issue #210.
+
+    int(np.log2(n_hydrogens)) floors, so n_hydrogens=6 used to map a 6x6 Fock
+    matrix onto 2 qubits, silently discarding rows/columns 4-5. Non-power-of-two
+    chain lengths must be rejected instead.
+    """
+    for bad_n_hydrogens in [1, 3, 6, 12]:
+        with pytest.raises(ValueError, match="power of two"):
+            Hchain_KS_hamiltonian(n_hydrogens=bad_n_hydrogens, R=1.2)
+
+
 def test_transformation_Hmatrix_Hqubit():
     # Pauli-Z Hamiltonian
     H = np.array([[1, 0], [0, -1]], dtype=complex)


### PR DESCRIPTION
Fixes #210.

`int(np.log2(n_hydrogens))` floors, so `n_hydrogens=6` mapped the 6×6 Fock matrix onto `2**2 = 4` basis functions, silently discarding rows/columns 4–5 and returning a wrong Hamiltonian with no warning — while the docstring only required an even atom count.

This raises `ValueError` for any `n_hydrogens` that is not a power of two (the validation runs before the PySCF calculation, so it's cheap) and documents the actual constraint. The regression test covers 1, 3, 6, and 12 and fails on the previous implementation.

Padding the Fock matrix to the next power of two was considered and rejected: it would introduce spurious zero-energy orbitals into the spectrum rather than an honest error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)