### PR TITLE
Remove broken group_commuting_pauli_terms_openfermion_hybrid

### DIFF
--- a/src/qlass/quantum_chemistry/__init__.py
+++ b/src/qlass/quantum_chemistry/__init__.py
@@ -12,7 +12,6 @@ from .hamiltonians import (
     LiH_hamiltonian_tapered,
     generate_random_hamiltonian,
     group_commuting_pauli_terms,
-    group_commuting_pauli_terms_openfermion_hybrid,
     pauli_commute,
     sparsepauliop_dictionary,
     transformation_Hmatrix_Hqubit,
@@ -31,7 +30,6 @@ __all__ = [
     "transformation_Hmatrix_Hqubit",
     "pauli_commute",
     "group_commuting_pauli_terms",
-    "group_commuting_pauli_terms_openfermion_hybrid",
     "sparsepauliop_dictionary",
     "Hchain_hamiltonian_WFT",
 ]

--- a/src/qlass/quantum_chemistry/hamiltonians.py
+++ b/src/qlass/quantum_chemistry/hamiltonians.py
@@ -159,65 +159,6 @@ def group_commuting_pauli_terms(hamiltonian: dict[str, float]) -> list[dict[str,
     return groups
 
 
-def group_commuting_pauli_terms_openfermion_hybrid(
-    hamiltonian: dict[str, float],
-) -> list[dict[str, float]]:
-    """
-    Hybrid approach that tries to use OpenFermion's grouping when possible,
-    fallback to our implementation otherwise.
-
-    This function attempts to leverage OpenFermion's optimized grouping functions
-    when they are applicable, while maintaining full compatibility with our
-    general commuting term grouping for all other cases.
-
-    Args:
-        hamiltonian (Dict[str, float]): Hamiltonian dictionary with Pauli string
-                                       keys and coefficient values
-
-    Returns:
-        List[Dict[str, float]]: List of grouped Hamiltonians, where each group
-                               contains mutually commuting Pauli terms
-    """
-    if not hamiltonian:
-        return []
-
-    try:
-        # Try to use OpenFermion's grouping for tensor product basis sets
-        from openfermion.measurements import group_into_tensor_product_basis_sets
-        from openfermion.ops import QubitOperator
-
-        # Convert Dict to QubitOperator
-        qubit_op = QubitOperator()
-        for pauli_string, coeff in hamiltonian.items():
-            # Convert our format to OpenFermion format
-            of_term = []
-            for i, pauli in enumerate(pauli_string):
-                if pauli != "I":
-                    of_term.append((i, pauli))
-
-            if of_term:
-                qubit_op += QubitOperator(tuple(of_term), coeff)
-            else:
-                # Identity term
-                qubit_op += QubitOperator((), coeff)
-
-        # Use OpenFermion's grouping
-        of_groups = group_into_tensor_product_basis_sets(qubit_op)
-
-        # Convert back to our format
-        groups = []
-        for of_group in of_groups:
-            group_dict = sparsepauliop_dictionary(of_group)
-            if group_dict:  # Only add non-empty groups
-                groups.append(group_dict)
-
-        return groups
-
-    except (ImportError, Exception):
-        # Fallback to our implementation if OpenFermion grouping fails
-        return group_commuting_pauli_terms(hamiltonian)
-
-
 def LiH_hamiltonian(
     R: float = 1.5, charge: int = 0, spin: int = 0, num_electrons: int = 2, num_orbitals: int = 2
 ) -> dict[str, float]:

--- a/tests/test_quantum_chemistry.py
+++ b/tests/test_quantum_chemistry.py
@@ -11,7 +11,6 @@ from qlass.quantum_chemistry import (
     brute_force_minimize,
     eig_decomp_lanczos,
     generate_random_hamiltonian,
-    group_commuting_pauli_terms_openfermion_hybrid,
     hamiltonian_matrix,
     lanczos,
     pauli_commute,
@@ -286,33 +285,6 @@ def check_groups(groups):
                 )
 
 
-def test_hybrid_grouping_openfermion_success():
-    """
-    Tests the hybrid grouping function assuming the OpenFermion backend succeeds.
-    """
-    # Define a Hamiltonian with two distinct groups that OpenFermion can separate
-    hamiltonian = {
-        "IZ": 1.0,
-        "ZI": -1.0,
-        "ZZ": 0.5,  # This group can be measured in the Z-basis
-        "XX": 0.2,  # This group requires a change to the X-basis
-        "XI": -0.3,  # This also requires a change to the X-basis
-    }
-
-    groups = group_commuting_pauli_terms_openfermion_hybrid(hamiltonian)
-
-    # OpenFermion's `group_into_tensor_product_basis_sets` will group by measurement basis.
-    # We expect two groups: one for Z-basis terms and one for X-basis terms.
-    assert len(groups) == 2, "Expected two measurement groups (Z-basis and X-basis)"
-
-    # Verify that the terms within each group are mutually commuting
-    check_groups(groups)
-
-    # Check that the total number of terms is conserved
-    total_terms_in_groups = sum(len(g) for g in groups)
-    assert total_terms_in_groups == len(hamiltonian)
-
-
 def test_Hchain_KS_hamiltonian(monkeypatch):
     try:
         H_qubit_dic, mo_energy, n_occ = Hchain_KS_hamiltonian(n_hydrogens=2, R=1.2)
@@ -349,39 +321,6 @@ def test_transformation_Hmatrix_Hqubit():
     assert pauli_term == ((0, "Z"),)
     assert np.isclose(coeff.real, 1.0, atol=1e-12)
     assert np.isclose(coeff.imag, 0.0, atol=1e-12)
-
-
-def test_hybrid_grouping_fallback_behavior(mocker):
-    """
-    Tests the fallback mechanism of the hybrid function by mocking an ImportError.
-    """
-    # Mock the OpenFermion import to trigger the fallback to the custom implementation
-    mocker.patch(
-        "openfermion.measurements.group_into_tensor_product_basis_sets",
-        side_effect=ImportError("Simulating OpenFermion not found"),
-    )
-
-    # Define a Hamiltonian. The custom grouper will find all mutually commuting terms.
-    hamiltonian = {
-        "XX": 1.0,
-        "YY": 1.0,  # XX and YY commute
-        "XI": 0.5,  # XI does not commute with YY
-        "IZ": -0.5,  # IZ commutes with all of the above
-    }
-
-    groups = group_commuting_pauli_terms_openfermion_hybrid(hamiltonian)
-
-    # The custom fallback grouper is greedy. The expected grouping is:
-    # Group 1: {"XX", "YY", "IZ"}
-    # Group 2: {"XI"}
-    assert len(groups) == 2, "Expected 2 groups from the fallback implementation"
-
-    # Verify that the terms within each group are mutually commuting
-    check_groups(groups)
-
-    # Check that all original terms are present in the final groups
-    all_grouped_terms = {term for group in groups for term in group}
-    assert all_grouped_terms == set(hamiltonian.keys())
 
 
 def test_Hchain_hamiltonian_WFT():


### PR DESCRIPTION
Fixes #209.

The OpenFermion path could never succeed: `group_into_tensor_product_basis_sets` returns a **dict**, and the code iterated it directly — yielding key tuples, not operators — so `sparsepauliop_dictionary(of_group)` always raised `AttributeError`, which the over-broad `except (ImportError, Exception)` silently swallowed. Every call in the function's history has fallen back to `group_commuting_pauli_terms`. Nothing in the package calls it.

**Why remove rather than fix**: OpenFermion's tensor-product-basis grouping is strictly *coarser* than the package's own `group_commuting_pauli_terms` (that function's docstring says as much), so even a working hybrid could only return a worse grouping than its own fallback. And since the broken function always behaved identically to `group_commuting_pauli_terms`, any external caller can switch to it with bit-identical results — the removal changes no observable behavior.

The two associated tests are removed too: `test_hybrid_grouping_openfermion_success` only passed because the crash it didn't know about triggered the fallback (which happens to produce 2 groups for its Hamiltonian), and `test_hybrid_grouping_fallback_behavior` mocked a failure to reach what was in fact the only reachable path.

Full quantum-chemistry + utils suites, ruff, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)