### PR TITLE
Release 0.2.4

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,6 +13,8 @@ authors:
   given-names: Nathan
   orcid: "https://orcid.org/0000-0002-8775-3667"
 doi: 10.5281/zenodo.18245793
+version: "0.2.4"
+date-released: "2026-07-04"
 message: If you use this software, please cite our article in the
   Journal of Open Source Software.
 preferred-citation:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,10 +7,12 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 
+from importlib.metadata import version as _package_version
+
 project = "qlass"
 copyright = "2025, Farrokh Labib, Nathan Shammah"
 author = "Farrokh Labib, Nathan Shammah"
-release = "0.2.3"
+release = _package_version("qlass")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "qlass"
-version = "0.2.3"
+version = "0.2.4"
 description = "VQE on linear optical circuits"
 authors = [{name = "Farrokh Labib", email = "farrokh@unitary.foundation"}]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -2365,7 +2365,7 @@ wheels = [
 
 [[package]]
 name = "qlass"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "numba" },


### PR DESCRIPTION
Prepares the v0.2.4 release:

- `pyproject.toml`: version 0.2.3 → 0.2.4 (and `uv.lock` re-locked).
- `CITATION.cff`: adds the previously missing `version` and `date-released` fields.
- `docs/conf.py`: `release` is now derived from installed package metadata instead of being hardcoded, so it can't drift on future bumps (one item from #220).

After merging, publish the **v0.2.4 draft release** — that triggers `cd.yml` (PyPI trusted publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)