### PR TITLE
Speed up test suite 7x and test the full supported Python range in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on force-pushes to the same ref
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
       runs-on: ubuntu-latest
@@ -22,11 +27,11 @@ jobs:
 
       - name: Run ruff linter
         run: |
-          uv run --group lint -p 3.12 ruff check .
+          uv run --locked --group lint -p 3.12 ruff check .
 
       - name: Run ruff formatter check
         run: |
-          uv run --group lint -p 3.12 ruff format --check .
+          uv run --locked --group lint -p 3.12 ruff format --check .
 
   type-check:
     runs-on: ubuntu-latest
@@ -39,10 +44,15 @@ jobs:
 
     - name: Run type checking
       run: |
-        uv run --group type-check -p 3.12 mypy src/qlass
+        uv run --locked --group type-check -p 3.12 mypy src/qlass
 
   test-and-coverage:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test every Python version the package claims to support
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Check out repository
       uses: actions/checkout@v6
@@ -52,13 +62,15 @@ jobs:
 
     - name: Run tests and collect coverage
       run: |
-        uv run --group test -p 3.12 pytest --cov --cov-report=xml
+        uv run --locked --group test -p ${{ matrix.python-version }} pytest --cov --cov-report=xml
       env:
         # This disables Numba's JIT for accurate coverage reporting
         QLASS_DISABLE_JIT: 1
 
     - name: Upload coverage to Codecov
-      if: github.event_name == 'pull_request'
+      # Upload once per run (from the 3.12 job), on pushes to main as well as
+      # PRs, so the coverage baseline stays current
+      if: matrix.python-version == '3.12'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -121,7 +121,7 @@ def test_vqe_pipeline():
     def executor(params, pauli_string):
         processor = le_ansatz(params, pauli_string)
         sampler = Sampler(processor)
-        samples = sampler.samples(10_000)
+        samples = sampler.samples(1_000)
         return samples
 
     # Number of qubits
@@ -138,7 +138,7 @@ def test_vqe_pipeline():
     )
 
     # Run the VQE optimization
-    vqe_energy = vqe.run(max_iterations=10, verbose=True)
+    vqe_energy = vqe.run(max_iterations=5, verbose=True)
 
     if not isinstance(vqe_energy, float):
         raise ValueError("Optimization result is not a valid float")
@@ -192,7 +192,10 @@ def test_evqe_pipeline():
 
         return samples
 
-    ham, scf_mo_energy, n_orbs = Hchain_KS_hamiltonian(4, 1.2)
+    # Real KS Hamiltonian, but a 2-state ensemble and few iterations keep this
+    # integration test fast (issue #188)
+    ham, scf_mo_energy, _ = Hchain_KS_hamiltonian(4, 1.2)
+    n_orbs = 2
 
     vqe = VQE(
         hamiltonian=ham,
@@ -201,7 +204,7 @@ def test_evqe_pipeline():
     )
 
     # Run the VQE optimization
-    vqe_energy = vqe.run(max_iterations=5, verbose=True, weight_option="weighted", cost="e-VQE")
+    vqe_energy = vqe.run(max_iterations=3, verbose=True, weight_option="weighted", cost="e-VQE")
 
     if not isinstance(vqe_energy, float):
         raise ValueError("Optimization result is not a valid float")
@@ -758,44 +761,38 @@ def test_parametershift_grad():
 
 
 def test_parametershift_grad_pipline_vqe():
-    ham = Hchain_hamiltonian_WFT(2, 0.741, tampering=True)
-
-    def executor(params, pauli_string):
-        # for VQE
-        processor = Bitstring_initial_states(1, 1, params, pauli_string)
-        samplers = Sampler(processor)
-        samples = samplers.samples(100)
-
-        return samples
+    # This test covers the jacobian="parameter_shift" wiring in VQE.run;
+    # photonic execution is covered by test_vqe_pipeline, and the gradient
+    # math by test_parametershift_grad — so the instant mock executor keeps
+    # this fast (issue #188).
+    ham = {"ZZ": 1.0, "IX": 0.5}
 
     # Initialize the VQE solver
     vqe = VQE(
         hamiltonian=ham,
-        executor=executor,
+        executor=mock_executor,
         num_params=4,  # Number of parameters in the linear entangled ansatz
         optimizer="SLSQP",
     )
 
     # Run the VQE optimization
-    vqe_energy = vqe.run(max_iterations=2, verbose=True, cost="VQE", jacobian=None)
+    vqe_energy = vqe.run(max_iterations=1, verbose=False, cost="VQE", jacobian=None)
     assert isinstance(vqe_energy, float)
-    vqe_energy = vqe.run(max_iterations=2, verbose=True, cost="VQE", jacobian="parameter_shift")
+    vqe_energy = vqe.run(max_iterations=1, verbose=False, cost="VQE", jacobian="parameter_shift")
     assert isinstance(vqe_energy, float)
     with pytest.raises(
         ValueError, match="Wrong keyward for Jacobian. It should be None or parameter_shift"
     ):
-        vqe_energy = vqe.run(max_iterations=1, verbose=True, cost="VQE", jacobian="paramtershift")
+        vqe_energy = vqe.run(max_iterations=1, verbose=False, cost="VQE", jacobian="paramtershift")
 
 
 def test_parametershift_grad_pipline_evqe():
-    ham, scf_mo_energy, n_orbs = Hchain_KS_hamiltonian(4, 0.784)
+    # Same as test_parametershift_grad_pipline_vqe, for the e-VQE branch:
+    # the mock executor returns a two-state ensemble instantly (issue #188).
+    ham = {"ZZ": 1.0, "IX": 0.5}
 
     def executor(params, pauli_string):
-        processors = Bitstring_initial_states(1, n_orbs, params, pauli_string, cost="e-VQE")
-        samplers = [Sampler(p) for p in processors]
-        samples = [sampler.samples(100) for sampler in samplers]
-
-        return samples
+        return [mock_executor(params, pauli_string) for _ in range(2)]
 
     # Initialize the VQE solver
     vqe = VQE(
@@ -807,12 +804,14 @@ def test_parametershift_grad_pipline_evqe():
     )
 
     # Run the VQE optimization
-    vqe_energy = vqe.run(max_iterations=2, verbose=True, cost="e-VQE", jacobian="parameter_shift")
+    vqe_energy = vqe.run(max_iterations=1, verbose=False, cost="e-VQE", jacobian="parameter_shift")
     assert isinstance(vqe_energy, float)
     with pytest.raises(
         ValueError, match="Wrong keyward for Jacobian. It should be None or parameter_shift"
     ):
-        vqe_energy = vqe.run(max_iterations=1, verbose=True, cost="e-VQE", jacobian="paramtershift")
+        vqe_energy = vqe.run(
+            max_iterations=1, verbose=False, cost="e-VQE", jacobian="paramtershift"
+        )
 
 
 # ===== Kerr Ansatz Tests =====


### PR DESCRIPTION
Fixes #188. Fixes #215.

**Test suite: 127s → 18s** (locally, same 125 tests)

Profiling showed four tests held 121 of the 127 seconds:

| test | before | after | how |
|---|---|---|---|
| `test_parametershift_grad_pipline_evqe` | 65.4s | ~0.1s | mock executor — this test verifies the `jacobian="parameter_shift"` wiring, not photonics; each SLSQP gradient cost 2×num_params full photonic loss evaluations |
| `test_parametershift_grad_pipline_vqe` | 33.5s | ~0.1s | same |
| `test_evqe_pipeline` | 16.7s | 9.0s | keeps the real Kohn-Sham H4 Hamiltonian end-to-end, but a 2-state ensemble and 3 iterations |
| `test_vqe_pipeline` | 5.4s | 3.4s | 1000 shots (was 10,000), 5 iterations |

The gradient math keeps its dedicated unit test (`test_parametershift_grad`), and real photonic compilation + sampling stays covered by the two pipeline integration tests — this trims redundancy, not coverage.

**CI (#215)**
- `test-and-coverage` now runs a **Python 3.10 / 3.11 / 3.12 / 3.13 matrix** — the package's version-conditional numpy/numba pins were never exercised before. Verified locally: the lock resolves and the full suite passes on 3.10; 3.13 resolves and imports.
- `concurrency` group cancels superseded runs on force-pushes.
- All jobs use `uv run --locked`, so a stale `uv.lock` fails loudly instead of silently re-resolving.
- Codecov uploads on pushes to main as well as PRs (from the 3.12 matrix job only, avoiding 4× duplicate uploads), so PR coverage diffs compare against a current baseline.

With the 7× suite speedup, the 4× matrix still nets out faster than CI was before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)