### PR TITLE
Restore the u3/cx transpile basis in the piquasso example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -159,7 +159,7 @@ Standard VQE using sampling-based executor with `Piquasso <https://piquasso.read
 
         ansatz_assigned = ansatz.assign_parameters(lp)
         ansatz_transpiled = transpile(
-            ansatz_assigned, basis_gates=["rz", "ry", "cx"], optimization_level=3,
+            ansatz_assigned, basis_gates=["u3", "cx"], optimization_level=3,
         )
 
         ansatz_rot = rotate_qubits(pauli_string, ansatz_transpiled.copy())

--- a/examples/vqe_example_piquasso.py
+++ b/examples/vqe_example_piquasso.py
@@ -40,9 +40,7 @@ def le_ansatz_piquasso(lp: np.ndarray, pauli_string: str) -> pq.Program:
     ansatz = n_local(num_qubits, "ry", "cx", reps=1, entanglement="linear")
 
     ansatz_assigned = ansatz.assign_parameters(lp)
-    ansatz_transpiled = transpile(
-        ansatz_assigned, basis_gates=["rz", "ry", "cx"], optimization_level=3
-    )
+    ansatz_transpiled = transpile(ansatz_assigned, basis_gates=["u3", "cx"], optimization_level=3)
 
     ansatz_rot = rotate_qubits(pauli_string, ansatz_transpiled.copy())
     program = dual_rail_encode_from_qiskit(ansatz_rot)


### PR DESCRIPTION
Follow-up to #238: the `rz/ry/cx` basis switch (a workaround for a perceval-interop bug with repeated `u`/`u3` gates) was applied too broadly. `vqe_example_piquasso.py` doesn't go through perceval-interop at all — piquasso's `dual_rail_encode_from_qiskit` handles `u3` fine but fails on the `rz/ry` basis with `ValueError: Unexpected outcomes: [0, 0]`.

Found by running all 13 tracked examples end-to-end on merged main: 12 passed, this one failed. With the revert it converges to within 0.002 Ha of the exact LiH energy again, and the matching docs snippet is updated.

Full example sweep on this branch: **13/13 OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)